### PR TITLE
Reduce symbols in final binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ All in `std::` namespace.
 PoolSTL provides:
 * `poolstl::par`: Substitute for [`std::execution::par`](https://en.cppreference.com/w/cpp/algorithm/execution_policy_tag). Parallelized using a [thread pool](https://github.com/alugowski/task-thread-pool).
 * `poolstl::seq`: Substitute for `std::execution::seq`. Simply calls the regular (non-policy) overload.
-* `poolstl::par_if()`: (C++17 only) choose parallel or sequential at runtime. See below.
+* `poolstl::par_if()`: Choose parallel or sequential at runtime. See below.
 
 In short, use `poolstl::par` to make your code parallel. Complete example:
 ```c++

--- a/include/poolstl/algorithm
+++ b/include/poolstl/algorithm
@@ -20,10 +20,8 @@ namespace std {
     template <class ExecPolicy, class RandIt1, class RandIt2>
     poolstl::internal::enable_if_par<ExecPolicy, RandIt2>
     copy(ExecPolicy &&policy, RandIt1 first, RandIt1 last, RandIt2 dest) {
-        auto futures = poolstl::internal::parallel_chunk_for(std::forward<ExecPolicy>(policy), first, last, dest,
-                     [](RandIt1 chunk_first, RandIt1 chunk_last, RandIt2 chunk_dest) {
-                          std::copy(chunk_first, chunk_last, chunk_dest);
-                     });
+        auto futures = poolstl::internal::parallel_chunk_for_2(std::forward<ExecPolicy>(policy), first, last, dest,
+                                                               std::copy<RandIt1, RandIt2>, (RandIt2*)nullptr);
         poolstl::internal::get_futures(futures);
         return poolstl::internal::advanced(dest, std::distance(first, last));
     }
@@ -52,10 +50,8 @@ namespace std {
     count_if(ExecPolicy&& policy, RandIt first, RandIt last, UnaryPredicate p) {
         using T = typename iterator_traits<RandIt>::difference_type;
 
-        auto futures = poolstl::internal::parallel_chunk_for(std::forward<ExecPolicy>(policy), first, last,
-                                                             [&p](RandIt chunk_first, RandIt chunk_last) {
-                                                                 return std::count_if(chunk_first, chunk_last, p);
-                                                             });
+        auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
+                                                               std::count_if<RandIt, UnaryPredicate>, (T*)nullptr, p);
 
         return poolstl::internal::cpp17::reduce(
             poolstl::internal::get_wrap(futures.begin()),
@@ -80,10 +76,8 @@ namespace std {
     template <class ExecPolicy, class RandIt, class Tp>
     poolstl::internal::enable_if_par<ExecPolicy, void>
     fill(ExecPolicy &&policy, RandIt first, RandIt last, const Tp& value) {
-        auto futures = poolstl::internal::parallel_chunk_for(std::forward<ExecPolicy>(policy), first, last,
-                                                             [&value](RandIt chunk_first, RandIt chunk_last) {
-                                                                 std::fill(chunk_first, chunk_last, value);
-                                                             });
+        auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
+                                                               std::fill<RandIt, Tp>, (void*)nullptr, value);
         poolstl::internal::get_futures(futures);
     }
 
@@ -113,7 +107,7 @@ namespace std {
         diff_t n = std::distance(first, last);
         std::atomic<diff_t> extremum(n);
 
-        auto futures = poolstl::internal::parallel_chunk_for(std::forward<ExecPolicy>(policy), first, last,
+        auto futures = poolstl::internal::parallel_chunk_for_gen(std::forward<ExecPolicy>(policy), first, last,
                                         [&first, &extremum, &p](RandIt chunk_first, RandIt chunk_last) {
                                             if (std::distance(first, chunk_first) > extremum) {
                                              // already found by another task
@@ -129,7 +123,8 @@ namespace std {
                                                     extremum.compare_exchange_weak(old, k);
                                                 }
                                             }
-                                        }, 8); // use small tasks so later ones may exit early if item is already found
+                                        }, (void*)nullptr,
+                                        8); // use small tasks so later ones may exit early if item is already found
         poolstl::internal::get_futures(futures);
         return extremum == n ? last : first + extremum;
     }
@@ -142,7 +137,12 @@ namespace std {
     poolstl::internal::enable_if_par<ExecPolicy, RandIt>
     find_if_not(ExecPolicy &&policy, RandIt first, RandIt last, UnaryPredicate p) {
         return std::find_if(std::forward<ExecPolicy>(policy), first, last,
-                            [&p](const typename std::iterator_traits<RandIt>::value_type& test) { return !p(test); });
+#if POOLSTL_HAVE_CXX17_LIB
+                            std::not_fn(p)
+#else
+                            [&p](const typename std::iterator_traits<RandIt>::value_type& test) { return !p(test); }
+#endif
+                            );
     }
 
     /**
@@ -163,13 +163,16 @@ namespace std {
     template <class ExecPolicy, class RandIt, class UnaryFunction>
     poolstl::internal::enable_if_par<ExecPolicy, void>
     for_each(ExecPolicy &&policy, RandIt first, RandIt last, UnaryFunction f) {
-        auto futures = poolstl::internal::parallel_chunk_for(std::forward<ExecPolicy>(policy), first, last,
-                                                             [&f](RandIt chunk_first, RandIt chunk_last) {
-                                                                 // std::for_each(chunk_first, chunk_last, f);
-                                                                 for (; chunk_first != chunk_last; ++chunk_first) {
-                                                                     f(*chunk_first);
-                                                                 }
-                                                             });
+//        auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
+//                                                               std::for_each<RandIt, UnaryFunction>,
+//                                                               (UnaryFunction*)nullptr, f);
+        auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
+                                             [&f](RandIt chunk_first, RandIt chunk_last) {
+//                                                 std::for_each(chunk_first, chunk_last, f);
+                                                 for (; chunk_first != chunk_last; ++chunk_first) {
+                                                     f(*chunk_first);
+                                                 }
+                                             }, (void*)nullptr);
         poolstl::internal::get_futures(futures);
     }
 
@@ -236,10 +239,10 @@ namespace std {
     transform(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1,
               RandIt2 dest, UnaryOperation unary_op) {
 
-        auto futures = poolstl::internal::parallel_chunk_for(std::forward<ExecPolicy>(policy), first1, last1, dest,
-                 [&unary_op](RandIt1 chunk_first1, RandIt1 chunk_last1, RandIt2 dest_first) {
-                      return poolstl::internal::cpp17::transform(chunk_first1, chunk_last1, dest_first, unary_op);
-                 });
+        auto futures = poolstl::internal::parallel_chunk_for_2(std::forward<ExecPolicy>(policy), first1, last1, dest,
+                                                               poolstl::internal::cpp17::transform<RandIt1, RandIt2,
+                                                                                                   UnaryOperation>,
+                                                               (RandIt2*)nullptr, unary_op);
         poolstl::internal::get_futures(futures);
         return dest + std::distance(first1, last1);
     }
@@ -253,12 +256,11 @@ namespace std {
     transform(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1,
               RandIt2 first2, RandIt3 dest, BinaryOperation binary_op) {
 
-        auto futures = poolstl::internal::parallel_chunk_for(std::forward<ExecPolicy>(policy), first1, last1,
-                                                             first2, dest,
-                 [&binary_op](RandIt1 chunk_first1, RandIt1 chunk_last1, RandIt1 chunk_first2, RandIt3 dest_first) {
-                     return poolstl::internal::cpp17::transform(chunk_first1, chunk_last1,
-                                                                chunk_first2, dest_first, binary_op);
-                 });
+        auto futures = poolstl::internal::parallel_chunk_for_3(std::forward<ExecPolicy>(policy), first1, last1,
+                                                               first2, dest,
+                                                               poolstl::internal::cpp17::transform<RandIt1, RandIt2,
+                                                                                              RandIt3, BinaryOperation>,
+                                                               (RandIt3*)nullptr, binary_op);
         poolstl::internal::get_futures(futures);
         return dest + std::distance(first1, last1);
     }
@@ -320,10 +322,9 @@ namespace poolstl {
     template <class ExecPolicy, class RandIt, class ChunkConstructor, class UnaryFunction>
     poolstl::internal::enable_if_par<ExecPolicy, void>
     for_each_chunk(ExecPolicy&& policy, RandIt first, RandIt last, ChunkConstructor construct, UnaryFunction f) {
-        auto futures = poolstl::internal::parallel_chunk_for(std::forward<ExecPolicy>(policy), first, last,
-                                                             [&construct, &f](RandIt chunk_first, RandIt chunk_last) {
-                                                                 for_each_chunk(chunk_first, chunk_last, construct, f);
-                                                             });
+        auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
+                                                               for_each_chunk<RandIt, ChunkConstructor, UnaryFunction>,
+                                                               (void *) nullptr, construct, f);
         poolstl::internal::get_futures(futures);
     }
 }

--- a/include/poolstl/algorithm
+++ b/include/poolstl/algorithm
@@ -10,6 +10,7 @@
 
 #include "execution"
 #include "internal/ttp_impl.hpp"
+#include "internal/thread_impl.hpp"
 
 namespace std {
 
@@ -18,7 +19,7 @@ namespace std {
      * See std::copy https://en.cppreference.com/w/cpp/algorithm/copy
      */
     template <class ExecPolicy, class RandIt1, class RandIt2>
-    poolstl::internal::enable_if_par<ExecPolicy, RandIt2>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt2>
     copy(ExecPolicy &&policy, RandIt1 first, RandIt1 last, RandIt2 dest) {
         if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
             return std::copy(first, last, dest);
@@ -35,7 +36,7 @@ namespace std {
      * See std::copy_n https://en.cppreference.com/w/cpp/algorithm/copy_n
      */
     template <class ExecPolicy, class RandIt1, class Size, class RandIt2>
-    poolstl::internal::enable_if_par<ExecPolicy, RandIt2>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt2>
     copy_n(ExecPolicy &&policy, RandIt1 first, Size n, RandIt2 dest) {
         if (n <= 0) {
             return dest;
@@ -50,7 +51,7 @@ namespace std {
      * See std::count_if https://en.cppreference.com/w/cpp/algorithm/count_if
      */
     template <class ExecPolicy, class RandIt, class UnaryPredicate>
-    poolstl::internal::enable_if_par<ExecPolicy, typename iterator_traits<RandIt>::difference_type>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, typename iterator_traits<RandIt>::difference_type>
     count_if(ExecPolicy&& policy, RandIt first, RandIt last, UnaryPredicate p) {
         if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
             return std::count_if(first, last, p);
@@ -59,7 +60,8 @@ namespace std {
         using T = typename iterator_traits<RandIt>::difference_type;
 
         auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
-                                                               std::count_if<RandIt, UnaryPredicate>, (T*)nullptr, p);
+                                                               std::count_if<RandIt, UnaryPredicate>,
+                                                               (T*)nullptr, 1, p);
 
         return poolstl::internal::cpp17::reduce(
             poolstl::internal::get_wrap(futures.begin()),
@@ -71,7 +73,7 @@ namespace std {
      * See std::count https://en.cppreference.com/w/cpp/algorithm/count
      */
     template <class ExecPolicy, class RandIt, class T>
-    poolstl::internal::enable_if_par<ExecPolicy, typename iterator_traits<RandIt>::difference_type>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, typename iterator_traits<RandIt>::difference_type>
     count(ExecPolicy&& policy, RandIt first, RandIt last, const T& value) {
         return std::count_if(std::forward<ExecPolicy>(policy), first, last,
                              [&value](const T& test) { return test == value; });
@@ -82,16 +84,15 @@ namespace std {
      * See std::fill https://en.cppreference.com/w/cpp/algorithm/fill
      */
     template <class ExecPolicy, class RandIt, class Tp>
-    poolstl::internal::enable_if_par<ExecPolicy, void>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, void>
     fill(ExecPolicy &&policy, RandIt first, RandIt last, const Tp& value) {
         if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
             std::fill(first, last, value);
             return;
         }
 
-        auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
-                                                               std::fill<RandIt, Tp>, (void*)nullptr, value);
-        poolstl::internal::get_futures(futures);
+        poolstl::internal::parallel_chunk_for_1_wait(std::forward<ExecPolicy>(policy), first, last,
+                                                     std::fill<RandIt, Tp>, (void*)nullptr, 1, value);
     }
 
     /**
@@ -99,7 +100,7 @@ namespace std {
      * See std::fill_n https://en.cppreference.com/w/cpp/algorithm/fill_n
      */
     template <class ExecPolicy, class RandIt, class Size, class Tp>
-    poolstl::internal::enable_if_par<ExecPolicy, RandIt>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt>
     fill_n(ExecPolicy &&policy, RandIt first, Size n, const Tp& value) {
         if (n <= 0) {
             return first;
@@ -114,7 +115,7 @@ namespace std {
      * See std::find_if https://en.cppreference.com/w/cpp/algorithm/find_if
      */
     template <class ExecPolicy, class RandIt, class UnaryPredicate>
-    poolstl::internal::enable_if_par<ExecPolicy, RandIt>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt>
     find_if(ExecPolicy &&policy, RandIt first, RandIt last, UnaryPredicate p) {
         if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
             return std::find_if(first, last, p);
@@ -124,7 +125,7 @@ namespace std {
         diff_t n = std::distance(first, last);
         std::atomic<diff_t> extremum(n);
 
-        auto futures = poolstl::internal::parallel_chunk_for_gen(std::forward<ExecPolicy>(policy), first, last,
+        poolstl::internal::parallel_chunk_for_1_wait(std::forward<ExecPolicy>(policy), first, last,
                                         [&first, &extremum, &p](RandIt chunk_first, RandIt chunk_last) {
                                             if (std::distance(first, chunk_first) > extremum) {
                                              // already found by another task
@@ -142,7 +143,6 @@ namespace std {
                                             }
                                         }, (void*)nullptr,
                                         8); // use small tasks so later ones may exit early if item is already found
-        poolstl::internal::get_futures(futures);
         return extremum == n ? last : first + extremum;
     }
 
@@ -151,7 +151,7 @@ namespace std {
      * See std::find_if_not https://en.cppreference.com/w/cpp/algorithm/find_if_not
      */
     template <class ExecPolicy, class RandIt, class UnaryPredicate>
-    poolstl::internal::enable_if_par<ExecPolicy, RandIt>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt>
     find_if_not(ExecPolicy &&policy, RandIt first, RandIt last, UnaryPredicate p) {
         return std::find_if(std::forward<ExecPolicy>(policy), first, last,
 #if POOLSTL_HAVE_CXX17_LIB
@@ -167,7 +167,7 @@ namespace std {
      * See std::find https://en.cppreference.com/w/cpp/algorithm/find
      */
     template <class ExecPolicy, class RandIt, class T>
-    poolstl::internal::enable_if_par<ExecPolicy, RandIt>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt>
     find(ExecPolicy &&policy, RandIt first, RandIt last, const T& value) {
         return std::find_if(std::forward<ExecPolicy>(policy), first, last,
                             [&value](const T& test) { return value == test; });
@@ -178,8 +178,10 @@ namespace std {
      * See std::for_each https://en.cppreference.com/w/cpp/algorithm/for_each
      */
     template <class ExecPolicy, class RandIt, class UnaryFunction>
-    poolstl::internal::enable_if_par<ExecPolicy, void>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, void>
     for_each(ExecPolicy &&policy, RandIt first, RandIt last, UnaryFunction f) {
+        // Using a lambda instead of just calling the non-policy std::for_each because it appears to
+        // result in a smaller binary.
         auto chunk_func = [&f](RandIt chunk_first, RandIt chunk_last) {
             for (; chunk_first != chunk_last; ++chunk_first) {
                 f(*chunk_first);
@@ -191,12 +193,8 @@ namespace std {
             return;
         }
 
-//        auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
-//                                                               std::for_each<RandIt, UnaryFunction>,
-//                                                               (UnaryFunction*)nullptr, f);
-        auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
-                                                               chunk_func, (void*)nullptr);
-        poolstl::internal::get_futures(futures);
+        poolstl::internal::parallel_chunk_for_1_wait(std::forward<ExecPolicy>(policy), first, last,
+                                                     chunk_func, (void*)nullptr, 1);
     }
 
     /**
@@ -204,7 +202,7 @@ namespace std {
      * See std::for_each_n https://en.cppreference.com/w/cpp/algorithm/for_each_n
      */
     template <class ExecPolicy, class RandIt, class Size, class UnaryFunction>
-    poolstl::internal::enable_if_par<ExecPolicy, RandIt>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt>
     for_each_n(ExecPolicy &&policy, RandIt first, Size n, UnaryFunction f) {
         RandIt last = poolstl::internal::advanced(first, n);
         std::for_each(std::forward<ExecPolicy>(policy), first, last, f);
@@ -216,7 +214,7 @@ namespace std {
      * See std::sort https://en.cppreference.com/w/cpp/algorithm/sort
      */
     template <class ExecPolicy, class RandIt, class Compare>
-    poolstl::internal::enable_if_par<ExecPolicy, void>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, void>
     sort(ExecPolicy &&policy, RandIt first, RandIt last, Compare comp) {
         if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
             std::sort(first, last, comp);
@@ -231,7 +229,7 @@ namespace std {
      * See std::sort https://en.cppreference.com/w/cpp/algorithm/sort
      */
     template <class ExecPolicy, class RandIt>
-    poolstl::internal::enable_if_par<ExecPolicy, void>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, void>
     sort(ExecPolicy &&policy, RandIt first, RandIt last) {
         using T = typename std::iterator_traits<RandIt>::value_type;
         std::sort(std::forward<ExecPolicy>(policy), first, last, std::less<T>());
@@ -242,7 +240,7 @@ namespace std {
      * See std::stable_sort https://en.cppreference.com/w/cpp/algorithm/stable_sort
      */
     template <class ExecPolicy, class RandIt, class Compare>
-    poolstl::internal::enable_if_par<ExecPolicy, void>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, void>
     stable_sort(ExecPolicy &&policy, RandIt first, RandIt last, Compare comp) {
         if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
             std::stable_sort(first, last, comp);
@@ -257,7 +255,7 @@ namespace std {
      * See std::stable_sort https://en.cppreference.com/w/cpp/algorithm/stable_sort
      */
     template <class ExecPolicy, class RandIt>
-    poolstl::internal::enable_if_par<ExecPolicy, void>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, void>
     stable_sort(ExecPolicy &&policy, RandIt first, RandIt last) {
         using T = typename std::iterator_traits<RandIt>::value_type;
         std::stable_sort(std::forward<ExecPolicy>(policy), first, last, std::less<T>());
@@ -268,7 +266,7 @@ namespace std {
      * See std::transform https://en.cppreference.com/w/cpp/algorithm/transform
      */
     template <class ExecPolicy, class RandIt1, class RandIt2, class UnaryOperation>
-    poolstl::internal::enable_if_par<ExecPolicy, RandIt2>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt2>
     transform(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1,
               RandIt2 dest, UnaryOperation unary_op) {
         if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
@@ -288,7 +286,7 @@ namespace std {
      * See std::transform https://en.cppreference.com/w/cpp/algorithm/transform
      */
     template <class ExecPolicy, class RandIt1, class RandIt2, class RandIt3, class BinaryOperation>
-    poolstl::internal::enable_if_par<ExecPolicy, RandIt3>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt3>
     transform(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1,
               RandIt2 first2, RandIt3 dest, BinaryOperation binary_op) {
         if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
@@ -309,7 +307,7 @@ namespace std {
      * See std::all_of https://en.cppreference.com/w/cpp/algorithm/all_of
      */
     template <class ExecPolicy, typename RandIt, typename Predicate>
-    poolstl::internal::enable_if_par<ExecPolicy, bool>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, bool>
     all_of(ExecPolicy&& policy, RandIt first, RandIt last, Predicate pred) {
         return last == std::find_if_not(std::forward<ExecPolicy>(policy), first, last, pred);
     }
@@ -319,7 +317,7 @@ namespace std {
      * See std::none_of https://en.cppreference.com/w/cpp/algorithm/none_of
      */
     template <class ExecPolicy, typename RandIt, typename Predicate>
-    poolstl::internal::enable_if_par<ExecPolicy, bool>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, bool>
     none_of(ExecPolicy&& policy, RandIt first, RandIt last, Predicate pred) {
         return last == std::find_if(std::forward<ExecPolicy>(policy), first, last, pred);
     }
@@ -329,7 +327,7 @@ namespace std {
      * See std::any_of https://en.cppreference.com/w/cpp/algorithm/any_of
      */
     template <class ExecPolicy, typename RandIt, typename Predicate>
-    poolstl::internal::enable_if_par<ExecPolicy, bool>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, bool>
     any_of(ExecPolicy&& policy, RandIt first, RandIt last, Predicate pred) {
         return !std::none_of(std::forward<ExecPolicy>(policy), first, last, pred);
     }
@@ -366,11 +364,9 @@ namespace poolstl {
             return;
         }
 
-        auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
-                                                               for_each_chunk<RandIt, ChunkConstructor, UnaryFunction>,
-                                                               (void *) nullptr, construct, f);
-        poolstl::internal::get_futures(futures);
-
+        poolstl::internal::parallel_chunk_for_1_wait(std::forward<ExecPolicy>(policy), first, last,
+                                                     for_each_chunk <RandIt, ChunkConstructor, UnaryFunction>,
+                                                     (void*)nullptr, 1, construct, f);
     }
 }
 

--- a/include/poolstl/algorithm
+++ b/include/poolstl/algorithm
@@ -20,6 +20,10 @@ namespace std {
     template <class ExecPolicy, class RandIt1, class RandIt2>
     poolstl::internal::enable_if_par<ExecPolicy, RandIt2>
     copy(ExecPolicy &&policy, RandIt1 first, RandIt1 last, RandIt2 dest) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            return std::copy(first, last, dest);
+        }
+
         auto futures = poolstl::internal::parallel_chunk_for_2(std::forward<ExecPolicy>(policy), first, last, dest,
                                                                std::copy<RandIt1, RandIt2>, (RandIt2*)nullptr);
         poolstl::internal::get_futures(futures);
@@ -48,6 +52,10 @@ namespace std {
     template <class ExecPolicy, class RandIt, class UnaryPredicate>
     poolstl::internal::enable_if_par<ExecPolicy, typename iterator_traits<RandIt>::difference_type>
     count_if(ExecPolicy&& policy, RandIt first, RandIt last, UnaryPredicate p) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            return std::count_if(first, last, p);
+        }
+
         using T = typename iterator_traits<RandIt>::difference_type;
 
         auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
@@ -76,6 +84,11 @@ namespace std {
     template <class ExecPolicy, class RandIt, class Tp>
     poolstl::internal::enable_if_par<ExecPolicy, void>
     fill(ExecPolicy &&policy, RandIt first, RandIt last, const Tp& value) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            std::fill(first, last, value);
+            return;
+        }
+
         auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
                                                                std::fill<RandIt, Tp>, (void*)nullptr, value);
         poolstl::internal::get_futures(futures);
@@ -103,6 +116,10 @@ namespace std {
     template <class ExecPolicy, class RandIt, class UnaryPredicate>
     poolstl::internal::enable_if_par<ExecPolicy, RandIt>
     find_if(ExecPolicy &&policy, RandIt first, RandIt last, UnaryPredicate p) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            return std::find_if(first, last, p);
+        }
+
         using diff_t = typename std::iterator_traits<RandIt>::difference_type;
         diff_t n = std::distance(first, last);
         std::atomic<diff_t> extremum(n);
@@ -163,16 +180,22 @@ namespace std {
     template <class ExecPolicy, class RandIt, class UnaryFunction>
     poolstl::internal::enable_if_par<ExecPolicy, void>
     for_each(ExecPolicy &&policy, RandIt first, RandIt last, UnaryFunction f) {
+        auto chunk_func = [&f](RandIt chunk_first, RandIt chunk_last) {
+            for (; chunk_first != chunk_last; ++chunk_first) {
+                f(*chunk_first);
+            }
+        };
+
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            chunk_func(first, last);
+            return;
+        }
+
 //        auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
 //                                                               std::for_each<RandIt, UnaryFunction>,
 //                                                               (UnaryFunction*)nullptr, f);
         auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
-                                             [&f](RandIt chunk_first, RandIt chunk_last) {
-//                                                 std::for_each(chunk_first, chunk_last, f);
-                                                 for (; chunk_first != chunk_last; ++chunk_first) {
-                                                     f(*chunk_first);
-                                                 }
-                                             }, (void*)nullptr);
+                                                               chunk_func, (void*)nullptr);
         poolstl::internal::get_futures(futures);
     }
 
@@ -195,6 +218,11 @@ namespace std {
     template <class ExecPolicy, class RandIt, class Compare>
     poolstl::internal::enable_if_par<ExecPolicy, void>
     sort(ExecPolicy &&policy, RandIt first, RandIt last, Compare comp) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            std::sort(first, last, comp);
+            return;
+        }
+
         poolstl::internal::parallel_sort(std::forward<ExecPolicy>(policy), first, last, comp, false);
     }
 
@@ -206,7 +234,7 @@ namespace std {
     poolstl::internal::enable_if_par<ExecPolicy, void>
     sort(ExecPolicy &&policy, RandIt first, RandIt last) {
         using T = typename std::iterator_traits<RandIt>::value_type;
-        poolstl::internal::parallel_sort(std::forward<ExecPolicy>(policy), first, last, std::less<T>(), false);
+        std::sort(std::forward<ExecPolicy>(policy), first, last, std::less<T>());
     }
 
     /**
@@ -216,6 +244,11 @@ namespace std {
     template <class ExecPolicy, class RandIt, class Compare>
     poolstl::internal::enable_if_par<ExecPolicy, void>
     stable_sort(ExecPolicy &&policy, RandIt first, RandIt last, Compare comp) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            std::stable_sort(first, last, comp);
+            return;
+        }
+
         poolstl::internal::parallel_sort(std::forward<ExecPolicy>(policy), first, last, comp, true);
     }
 
@@ -227,7 +260,7 @@ namespace std {
     poolstl::internal::enable_if_par<ExecPolicy, void>
     stable_sort(ExecPolicy &&policy, RandIt first, RandIt last) {
         using T = typename std::iterator_traits<RandIt>::value_type;
-        poolstl::internal::parallel_sort(std::forward<ExecPolicy>(policy), first, last, std::less<T>(), true);
+        std::stable_sort(std::forward<ExecPolicy>(policy), first, last, std::less<T>());
     }
 
     /**
@@ -238,6 +271,9 @@ namespace std {
     poolstl::internal::enable_if_par<ExecPolicy, RandIt2>
     transform(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1,
               RandIt2 dest, UnaryOperation unary_op) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            return poolstl::internal::cpp17::transform(first1, last1, dest, unary_op);
+        }
 
         auto futures = poolstl::internal::parallel_chunk_for_2(std::forward<ExecPolicy>(policy), first1, last1, dest,
                                                                poolstl::internal::cpp17::transform<RandIt1, RandIt2,
@@ -255,6 +291,9 @@ namespace std {
     poolstl::internal::enable_if_par<ExecPolicy, RandIt3>
     transform(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1,
               RandIt2 first2, RandIt3 dest, BinaryOperation binary_op) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            return poolstl::internal::cpp17::transform(first1, last1, first2, dest, binary_op);
+        }
 
         auto futures = poolstl::internal::parallel_chunk_for_3(std::forward<ExecPolicy>(policy), first1, last1,
                                                                first2, dest,
@@ -320,12 +359,18 @@ namespace poolstl {
      * but cannot be shared by all parallel iterations.
      */
     template <class ExecPolicy, class RandIt, class ChunkConstructor, class UnaryFunction>
-    poolstl::internal::enable_if_par<ExecPolicy, void>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, void>
     for_each_chunk(ExecPolicy&& policy, RandIt first, RandIt last, ChunkConstructor construct, UnaryFunction f) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            for_each_chunk(first, last, construct, f);
+            return;
+        }
+
         auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
                                                                for_each_chunk<RandIt, ChunkConstructor, UnaryFunction>,
                                                                (void *) nullptr, construct, f);
         poolstl::internal::get_futures(futures);
+
     }
 }
 

--- a/include/poolstl/execution
+++ b/include/poolstl/execution
@@ -9,6 +9,7 @@
 
 #include <memory>
 #include <mutex>
+#include <stdexcept>
 #include <type_traits>
 
 #include "internal/task_thread_pool.hpp"
@@ -46,8 +47,8 @@ namespace poolstl {
          */
         struct sequenced_policy : public poolstl_policy {
             POOLSTL_NO_DISCARD ttp::task_thread_pool* pool() const {
-                // never called
-                return nullptr;
+                // never called, but must exist for C++11 support
+                throw std::runtime_error("poolSTL: requested thread pool for seq policy.");
             }
 
             POOLSTL_NO_DISCARD bool par_allowed() const {

--- a/include/poolstl/execution
+++ b/include/poolstl/execution
@@ -38,7 +38,8 @@ namespace poolstl {
         /**
          * Base class for all poolSTL policies.
          */
-        struct poolstl_policy {};
+        struct poolstl_policy {
+        };
 
         /**
          * A sequential policy that simply forwards to the non-policy overload.
@@ -89,6 +90,39 @@ namespace poolstl {
         constexpr sequenced_policy seq{};
         constexpr parallel_policy par{};
 
+        /**
+         * EXPERIMENTAL: Subject to significant changes or removal.
+         * Use pure threads for each operation instead of a shared thread pool.
+         *
+         * Advantage:
+         *  - Fewer symbols (no packaged_task with its operators, destructors, vtable, etc) means smaller binary
+         *    which can mean a lot when there are many calls.
+         *  - No thread pool to manage.
+         *
+         * Disadvantages:
+         *  - Threads are started and joined for every operation, so it is harder to amortize that cost.
+         *  - Barely any algorithms are supported.
+         */
+        struct pure_threads_policy : public poolstl_policy {
+            explicit pure_threads_policy(unsigned int num_threads, bool par_ok): num_threads(num_threads),
+                                                                                 par_ok(par_ok) {}
+
+            POOLSTL_NO_DISCARD unsigned int get_num_threads() const {
+                if (num_threads == 0) {
+                    return std::thread::hardware_concurrency();
+                }
+                return num_threads;
+            }
+
+            POOLSTL_NO_DISCARD bool par_allowed() const {
+                return par_ok;
+            }
+
+        protected:
+            unsigned int num_threads = 1;
+            bool par_ok = true;
+        };
+
 
 #if POOLSTL_HAVE_CXX17
         /**
@@ -114,7 +148,7 @@ namespace poolstl {
          * Choose parallel or sequential at runtime.
          *
          * @param call_par Whether to use a parallel policy.
-         * @return `par` if call_par is true, else `seq`.
+         * @return `par` if call_par is true, else a sequential policy (like `seq`).
          */
         inline parallel_policy par_if(bool call_par) {
             return parallel_policy{nullptr, call_par};
@@ -124,10 +158,21 @@ namespace poolstl {
          * Choose parallel or sequential at runtime, with pool selection.
          *
          * @param call_par Whether to use a parallel policy.
-         * @return `par.on(pool)` if call_par is true, else `seq`.
+         * @return `par.on(pool)` if call_par is true, else a sequential policy (like `seq`).
          */
         inline parallel_policy par_if(bool call_par, ttp::task_thread_pool& pool) {
             return parallel_policy{&pool, call_par};
+        }
+
+        /**
+         * EXPERIMENTAL: Subject to significant changes or removal. See `pure_threads_policy`.
+         * Choose parallel or sequential at runtime, with thread count selection.
+         *
+         * @param call_par Whether to use a parallel policy.
+         * @return `par.on(pool)` if call_par is true, else `seq`.
+         */
+        inline pure_threads_policy par_if_threads(bool call_par, unsigned int num_threads) {
+            return pure_threads_policy{num_threads, call_par};
         }
     }
 
@@ -173,6 +218,10 @@ namespace poolstl {
         bool is_seq(const ExecPolicy& policy) {
             return !policy.par_allowed();
         }
+
+        template <class ExecPolicy>
+        using is_pure_threads_policy = std::is_same<poolstl::execution::pure_threads_policy,
+            typename std::remove_cv<typename std::remove_reference<ExecPolicy>::type>::type>;
 
 #if POOLSTL_HAVE_CXX17
         /**

--- a/include/poolstl/execution
+++ b/include/poolstl/execution
@@ -36,31 +36,54 @@ namespace poolstl {
         }
 
         /**
+         * Base class for all poolSTL policies.
+         */
+        struct poolstl_policy {};
+
+        /**
          * A sequential policy that simply forwards to the non-policy overload.
          */
-        struct sequenced_policy {};
+        struct sequenced_policy : public poolstl_policy {
+            POOLSTL_NO_DISCARD ttp::task_thread_pool* pool() const {
+                // never called
+                return nullptr;
+            }
+
+            POOLSTL_NO_DISCARD bool par_allowed() const {
+                return false;
+            }
+        };
 
         /**
          * A parallel policy that can use a user-specified thread pool or a default one.
          */
-        struct parallel_policy {
+        struct parallel_policy : public poolstl_policy {
             parallel_policy() = default;
-            explicit parallel_policy(ttp::task_thread_pool& on_pool): on_pool(&on_pool) {}
+            explicit parallel_policy(ttp::task_thread_pool* on_pool, bool par_ok): on_pool(on_pool), par_ok(par_ok) {}
 
             parallel_policy on(ttp::task_thread_pool& pool) const {
-                return parallel_policy{pool};
+                return parallel_policy{&pool, par_ok};
             }
 
-            POOLSTL_NO_DISCARD ttp::task_thread_pool& pool() const {
+            parallel_policy par_if(bool call_par) const {
+                return parallel_policy{on_pool, call_par};
+            }
+
+            POOLSTL_NO_DISCARD ttp::task_thread_pool* pool() const {
                 if (on_pool) {
-                    return *on_pool;
+                    return on_pool;
                 } else {
-                    return *(internal::get_default_pool());
+                    return internal::get_default_pool().get();
                 }
+            }
+
+            POOLSTL_NO_DISCARD bool par_allowed() const {
+                return par_ok;
             }
 
         protected:
             ttp::task_thread_pool *on_pool = nullptr;
+            bool par_ok = true;
         };
 
         constexpr sequenced_policy seq{};
@@ -85,18 +108,16 @@ namespace poolstl {
                 poolstl::execution::sequenced_policy>;
         }
 
+#endif
+
         /**
          * Choose parallel or sequential at runtime.
          *
          * @param call_par Whether to use a parallel policy.
          * @return `par` if call_par is true, else `seq`.
          */
-        inline variant_policy<internal::poolstl_policy_variant> par_if(bool call_par) {
-            if (call_par) {
-                return variant_policy(internal::poolstl_policy_variant(par));
-            } else {
-                return variant_policy(internal::poolstl_policy_variant(seq));
-            }
+        inline parallel_policy par_if(bool call_par) {
+            return parallel_policy{nullptr, call_par};
         }
 
         /**
@@ -105,21 +126,16 @@ namespace poolstl {
          * @param call_par Whether to use a parallel policy.
          * @return `par.on(pool)` if call_par is true, else `seq`.
          */
-        inline variant_policy<internal::poolstl_policy_variant> par_if(bool call_par, ttp::task_thread_pool& pool) {
-            if (call_par) {
-                return variant_policy(internal::poolstl_policy_variant(par.on(pool)));
-            } else {
-                return variant_policy(internal::poolstl_policy_variant(seq));
-            }
+        inline parallel_policy par_if(bool call_par, ttp::task_thread_pool& pool) {
+            return parallel_policy{&pool, call_par};
         }
-#endif
     }
 
     using execution::seq;
     using execution::par;
+    using execution::par_if;
 #if POOLSTL_HAVE_CXX17
     using execution::variant_policy;
-    using execution::par_if;
 #endif
 
     namespace internal {
@@ -142,6 +158,21 @@ namespace poolstl {
                 std::is_same<poolstl::execution::parallel_policy,
                     typename std::remove_cv<typename std::remove_reference<ExecPolicy>::type>::type>::value,
                 Tp>::type;
+
+        /**
+         * To enable/disable par overload resolution
+         */
+        template <class ExecPolicy, class Tp>
+        using enable_if_poolstl_policy =
+            typename std::enable_if<
+                std::is_base_of<poolstl::execution::poolstl_policy,
+                    typename std::remove_cv<typename std::remove_reference<ExecPolicy>::type>::type>::value,
+                Tp>::type;
+
+        template <class ExecPolicy>
+        bool is_seq(const ExecPolicy& policy) {
+            return !policy.par_allowed();
+        }
 
 #if POOLSTL_HAVE_CXX17
         /**

--- a/include/poolstl/internal/task_thread_pool.hpp
+++ b/include/poolstl/internal/task_thread_pool.hpp
@@ -279,8 +279,10 @@ namespace task_thread_pool {
 #endif
         >
         TTP_NODISCARD std::future<R> submit(F&& func, A&&... args) {
-#if defined(_MSVC_LANG)
-            // MSVC's packaged_task is not movable.
+#if defined(_MSC_VER)
+            // MSVC's packaged_task is not movable even though it should be.
+            // Discussion about this bug and its future fix:
+            // https://developercommunity.visualstudio.com/t/unable-to-move-stdpackaged-task-into-any-stl-conta/108672
             std::shared_ptr<std::packaged_task<R()>> ptask =
                 std::make_shared<std::packaged_task<R()>>(std::bind(std::forward<F>(func), std::forward<A>(args)...));
             submit_detach([ptask] { (*ptask)(); });

--- a/include/poolstl/internal/thread_impl.hpp
+++ b/include/poolstl/internal/thread_impl.hpp
@@ -1,0 +1,61 @@
+// Copyright (C) 2023 Adam Lugowski. All rights reserved.
+// Use of this source code is governed by:
+// the BSD 2-clause license, the MIT license, or at your choosing the BSL-1.0 license found in the LICENSE.*.txt files.
+// SPDX-License-Identifier: BSD-2-Clause OR MIT OR BSL-1.0
+
+#ifndef POOLSTL_INTERNAL_THREAD_IMPL_HPP
+#define POOLSTL_INTERNAL_THREAD_IMPL_HPP
+
+/**
+ * EXPERIMENTAL: Subject to significant changes or removal.
+ * An implementation using only std::thread and no thread pool at all.
+ *
+ * Advantage:
+ *  - Fewer symbols (no packaged_task with its operators, destructors, vtable, etc) means smaller binary
+ *    which can mean a lot when there are many calls like with many templates.
+ *  - No thread pool to manage.
+ *
+ * Disadvantages:
+ *  - Threads are started and joined for every operation, so it is harder to amortize that cost.
+ *  - Barely any algorithms are supported.
+ */
+
+#include <algorithm>
+#include <thread>
+#include <numeric>
+#include <utility>
+#include <vector>
+
+#include "utils.hpp"
+#include "../execution"
+
+namespace poolstl {
+    namespace internal {
+
+        template <class ExecPolicy, class RandIt, class Chunk, class ChunkRet, typename... A>
+        typename std::enable_if<is_pure_threads_policy<ExecPolicy>::value, void>::type
+        parallel_chunk_for_1_wait(ExecPolicy &&policy, RandIt first, RandIt last,
+                                  Chunk chunk, ChunkRet*, int extra_split_factor, A&&... chunk_args) {
+            std::vector<std::thread> threads;
+            auto chunk_size = get_chunk_size(first, last, extra_split_factor * policy.get_num_threads());
+
+            while (first < last) {
+                auto iter_chunk_size = get_iter_chunk_size(first, last, chunk_size);
+                RandIt loop_end = advanced(first, iter_chunk_size);
+
+                threads.emplace_back(std::thread(std::forward<Chunk>(chunk), first, loop_end,
+                                                 std::forward<A>(chunk_args)...));
+
+                first = loop_end;
+            }
+
+            for (auto& thread : threads) {
+                if (thread.joinable()) {
+                    thread.join();
+                }
+            }
+        }
+    }
+}
+
+#endif

--- a/include/poolstl/internal/ttp_impl.hpp
+++ b/include/poolstl/internal/ttp_impl.hpp
@@ -25,7 +25,7 @@ namespace poolstl {
         std::vector<std::future<void>>
         parallel_apply(ExecPolicy &&policy, Op op, const ArgContainer& args_list) {
             std::vector<std::future<void>> futures;
-            auto& task_pool = policy.pool();
+            auto& task_pool = *policy.pool();
 
             for (const auto& args : args_list) {
                 futures.emplace_back(task_pool.submit([](Op op, const auto& args_fwd) {
@@ -48,7 +48,7 @@ namespace poolstl {
                                                      std::declval<RandIt>()))*)nullptr,
                                int extra_split_factor = 1) {
             std::vector<std::future<ChunkRet>> futures;
-            auto& task_pool = policy.pool();
+            auto& task_pool = *policy.pool();
             auto chunk_size = get_chunk_size(first, last, extra_split_factor * task_pool.get_num_threads());
 
             while (first < last) {
@@ -71,7 +71,7 @@ namespace poolstl {
         parallel_chunk_for_1(ExecPolicy &&policy, RandIt first, RandIt last,
                              Chunk chunk, ChunkRet*, A&&... chunk_args) {
             std::vector<std::future<ChunkRet>> futures;
-            auto& task_pool = policy.pool();
+            auto& task_pool = *policy.pool();
             auto chunk_size = get_chunk_size(first, last, task_pool.get_num_threads());
 
             while (first < last) {
@@ -95,7 +95,7 @@ namespace poolstl {
         parallel_chunk_for_2(ExecPolicy &&policy, RandIt1 first1, RandIt1 last1, RandIt2 first2,
                              Chunk chunk, ChunkRet*, A&&... chunk_args) {
             std::vector<std::future<ChunkRet>> futures;
-            auto& task_pool = policy.pool();
+            auto& task_pool = *policy.pool();
             auto chunk_size = get_chunk_size(first1, last1, task_pool.get_num_threads());
 
             while (first1 < last1) {
@@ -121,7 +121,7 @@ namespace poolstl {
         parallel_chunk_for_3(ExecPolicy &&policy, RandIt1 first1, RandIt1 last1, RandIt2 first2, RandIt3 first3,
                            Chunk chunk, ChunkRet*, A&&... chunk_args) {
             std::vector<std::future<ChunkRet>> futures;
-            auto& task_pool = policy.pool();
+            auto& task_pool = *policy.pool();
             auto chunk_size = get_chunk_size(first1, last1, task_pool.get_num_threads());
 
             while (first1 < last1) {
@@ -163,7 +163,7 @@ namespace poolstl {
 
             // Merge the sorted ranges
             using SortedRange = std::pair<RandIt, RandIt>;
-            auto& task_pool = policy.pool();
+            auto& task_pool = *policy.pool();
             std::vector<SortedRange> subranges;
             do {
                 for (auto& future : futures) {

--- a/include/poolstl/numeric
+++ b/include/poolstl/numeric
@@ -21,7 +21,7 @@ namespace std {
      * See std::exclusive_scan https://en.cppreference.com/w/cpp/algorithm/exclusive_scan
      */
     template <class ExecPolicy, class RandIt1, class RandIt2, class T, class BinaryOp>
-    poolstl::internal::enable_if_par<ExecPolicy, RandIt2>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt2>
     exclusive_scan(ExecPolicy &&policy, RandIt1 first, RandIt1 last, RandIt2 dest, T init, BinaryOp binop) {
         if (first == last) {
             return dest;
@@ -74,7 +74,7 @@ namespace std {
      * See std::exclusive_scan https://en.cppreference.com/w/cpp/algorithm/exclusive_scan
      */
     template <class ExecPolicy, class RandIt1, class RandIt2, class T>
-    poolstl::internal::enable_if_par<ExecPolicy, RandIt2>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt2>
     exclusive_scan(ExecPolicy &&policy, RandIt1 first, RandIt1 last, RandIt2 dest, T init) {
         return std::exclusive_scan(std::forward<ExecPolicy>(policy), first, last, dest, init, std::plus<T>());
     }
@@ -85,7 +85,7 @@ namespace std {
      * See std::reduce https://en.cppreference.com/w/cpp/algorithm/reduce
      */
     template <class ExecPolicy, class RandIt, class T, class BinaryOp>
-    poolstl::internal::enable_if_par<ExecPolicy, T>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, T>
     reduce(ExecPolicy &&policy, RandIt first, RandIt last, T init, BinaryOp binop) {
         if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
             return poolstl::internal::cpp17::reduce(first, last, init, binop);
@@ -93,7 +93,7 @@ namespace std {
 
         auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
                                                                poolstl::internal::cpp17::reduce<RandIt, T, BinaryOp>,
-                                                               (T*)nullptr, init, binop);
+                                                               (T*)nullptr, 1, init, binop);
 
         return poolstl::internal::cpp17::reduce(
             poolstl::internal::get_wrap(futures.begin()),
@@ -105,7 +105,7 @@ namespace std {
      * See std::reduce https://en.cppreference.com/w/cpp/algorithm/reduce
      */
     template <class ExecPolicy, class RandIt, class T>
-    poolstl::internal::enable_if_par<ExecPolicy, T>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, T>
     reduce(ExecPolicy &&policy, RandIt first, RandIt last, T init) {
         return std::reduce(std::forward<ExecPolicy>(policy), first, last, init, std::plus<T>());
     }
@@ -115,7 +115,7 @@ namespace std {
      * See std::reduce https://en.cppreference.com/w/cpp/algorithm/reduce
      */
     template <class ExecPolicy, class RandIt>
-    poolstl::internal::enable_if_par<
+    poolstl::internal::enable_if_poolstl_policy<
         ExecPolicy, typename std::iterator_traits<RandIt>::value_type>
     reduce(ExecPolicy &&policy, RandIt first, RandIt last) {
         return std::reduce(std::forward<ExecPolicy>(policy), first, last,
@@ -128,7 +128,7 @@ namespace std {
      * See std::transform_reduce https://en.cppreference.com/w/cpp/algorithm/transform_reduce
      */
     template <class ExecPolicy, class RandIt1, class T, class BinaryReductionOp, class UnaryTransformOp>
-    poolstl::internal::enable_if_par<ExecPolicy, T>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, T>
     transform_reduce(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1, T init,
                      BinaryReductionOp reduce_op, UnaryTransformOp transform_op) {
         if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
@@ -138,7 +138,7 @@ namespace std {
         auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first1, last1,
                                                                std::transform_reduce<RandIt1, T,
                                                                                    BinaryReductionOp, UnaryTransformOp>,
-                                                               (T*)nullptr, init, reduce_op, transform_op);
+                                                               (T*)nullptr, 1, init, reduce_op, transform_op);
 
         return poolstl::internal::cpp17::reduce(
             poolstl::internal::get_wrap(futures.begin()),
@@ -150,7 +150,7 @@ namespace std {
      * See std::transform_reduce https://en.cppreference.com/w/cpp/algorithm/transform_reduce
      */
     template <class ExecPolicy, class RandIt1, class RandIt2, class T, class BinaryReductionOp, class BinaryTransformOp>
-    poolstl::internal::enable_if_par<ExecPolicy, T>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, T>
     transform_reduce(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1, RandIt2 first2, T init,
                      BinaryReductionOp reduce_op, BinaryTransformOp transform_op) {
         if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
@@ -172,7 +172,7 @@ namespace std {
      * See std::transform_reduce https://en.cppreference.com/w/cpp/algorithm/transform_reduce
      */
     template< class ExecPolicy, class RandIt1, class RandIt2, class T >
-    poolstl::internal::enable_if_par<ExecPolicy, T>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, T>
     transform_reduce(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1, RandIt2 first2, T init ) {
         return transform_reduce(std::forward<ExecPolicy>(policy),
             first1, last1, first2, init, std::plus<>(), std::multiplies<>());

--- a/include/poolstl/numeric
+++ b/include/poolstl/numeric
@@ -27,6 +27,10 @@ namespace std {
             return dest;
         }
 
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            return std::exclusive_scan(first, last, dest, init, binop);
+        }
+
         // Pass 1: Chunk the input and find the sum of each chunk
         auto futures = poolstl::internal::parallel_chunk_for_gen(std::forward<ExecPolicy>(policy), first, last,
                              [binop](RandIt1 chunk_first, RandIt1 chunk_last) {
@@ -83,6 +87,10 @@ namespace std {
     template <class ExecPolicy, class RandIt, class T, class BinaryOp>
     poolstl::internal::enable_if_par<ExecPolicy, T>
     reduce(ExecPolicy &&policy, RandIt first, RandIt last, T init, BinaryOp binop) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            return poolstl::internal::cpp17::reduce(first, last, init, binop);
+        }
+
         auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
                                                                poolstl::internal::cpp17::reduce<RandIt, T, BinaryOp>,
                                                                (T*)nullptr, init, binop);
@@ -123,6 +131,9 @@ namespace std {
     poolstl::internal::enable_if_par<ExecPolicy, T>
     transform_reduce(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1, T init,
                      BinaryReductionOp reduce_op, UnaryTransformOp transform_op) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            return std::transform_reduce(first1, last1, init, reduce_op, transform_op);
+        }
 
         auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first1, last1,
                                                                std::transform_reduce<RandIt1, T,
@@ -142,6 +153,9 @@ namespace std {
     poolstl::internal::enable_if_par<ExecPolicy, T>
     transform_reduce(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1, RandIt2 first2, T init,
                      BinaryReductionOp reduce_op, BinaryTransformOp transform_op) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            return std::transform_reduce(first1, last1, first2, init, reduce_op, transform_op);
+        }
 
         auto futures = poolstl::internal::parallel_chunk_for_2(std::forward<ExecPolicy>(policy), first1, last1, first2,
                                                                std::transform_reduce<RandIt1, RandIt2, T,

--- a/include/poolstl/numeric
+++ b/include/poolstl/numeric
@@ -28,7 +28,7 @@ namespace std {
         }
 
         // Pass 1: Chunk the input and find the sum of each chunk
-        auto futures = poolstl::internal::parallel_chunk_for(std::forward<ExecPolicy>(policy), first, last,
+        auto futures = poolstl::internal::parallel_chunk_for_gen(std::forward<ExecPolicy>(policy), first, last,
                              [binop](RandIt1 chunk_first, RandIt1 chunk_last) {
                                  auto sum = std::accumulate(chunk_first, chunk_last, T{}, binop);
                                  return std::make_tuple(std::make_pair(chunk_first, chunk_last), sum);
@@ -83,10 +83,9 @@ namespace std {
     template <class ExecPolicy, class RandIt, class T, class BinaryOp>
     poolstl::internal::enable_if_par<ExecPolicy, T>
     reduce(ExecPolicy &&policy, RandIt first, RandIt last, T init, BinaryOp binop) {
-        auto futures = poolstl::internal::parallel_chunk_for(std::forward<ExecPolicy>(policy), first, last,
-                                  [init, binop](RandIt chunk_first, RandIt chunk_last) {
-                                      return poolstl::internal::cpp17::reduce(chunk_first, chunk_last, init, binop);
-                                  });
+        auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first, last,
+                                                               poolstl::internal::cpp17::reduce<RandIt, T, BinaryOp>,
+                                                               (T*)nullptr, init, binop);
 
         return poolstl::internal::cpp17::reduce(
             poolstl::internal::get_wrap(futures.begin()),
@@ -125,10 +124,10 @@ namespace std {
     transform_reduce(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1, T init,
                      BinaryReductionOp reduce_op, UnaryTransformOp transform_op) {
 
-        auto futures = poolstl::internal::parallel_chunk_for(std::forward<ExecPolicy>(policy), first1, last1,
-             [&init, &reduce_op, &transform_op](RandIt1 chunk_first1, RandIt1 chunk_last1) {
-                 return std::transform_reduce(chunk_first1, chunk_last1, init, reduce_op, transform_op);
-             });
+        auto futures = poolstl::internal::parallel_chunk_for_1(std::forward<ExecPolicy>(policy), first1, last1,
+                                                               std::transform_reduce<RandIt1, T,
+                                                                                   BinaryReductionOp, UnaryTransformOp>,
+                                                               (T*)nullptr, init, reduce_op, transform_op);
 
         return poolstl::internal::cpp17::reduce(
             poolstl::internal::get_wrap(futures.begin()),
@@ -144,10 +143,10 @@ namespace std {
     transform_reduce(ExecPolicy&& policy, RandIt1 first1, RandIt1 last1, RandIt2 first2, T init,
                      BinaryReductionOp reduce_op, BinaryTransformOp transform_op) {
 
-        auto futures = poolstl::internal::parallel_chunk_for(std::forward<ExecPolicy>(policy), first1, last1, first2,
-             [&init, &reduce_op, &transform_op](RandIt1 chunk_first1, RandIt1 chunk_last1, RandIt2 chunk_first2) {
-                 return std::transform_reduce(chunk_first1, chunk_last1, chunk_first2, init, reduce_op, transform_op);
-             });
+        auto futures = poolstl::internal::parallel_chunk_for_2(std::forward<ExecPolicy>(policy), first1, last1, first2,
+                                                               std::transform_reduce<RandIt1, RandIt2, T,
+                                                                                  BinaryReductionOp, BinaryTransformOp>,
+                                                               (T*)nullptr, init, reduce_op, transform_op);
 
         return poolstl::internal::cpp17::reduce(
             poolstl::internal::get_wrap(futures.begin()),

--- a/tests/cpp11_test.cpp
+++ b/tests/cpp11_test.cpp
@@ -14,9 +14,18 @@
 
 int main() {
     std::vector<int> v = {0, 1, 2, 3, 4, 5, 6, 7, 8, 9};
+
+    // sequential
+    std::for_each(poolstl::seq, v.cbegin(), v.cend(), [](int x) {
+        std::cout << x;
+    });
+    std::cout << std::endl;
+
+    // parallel
     std::for_each(poolstl::par, v.cbegin(), v.cend(), [](int x) {
         std::cout << x;
     });
     std::cout << std::endl;
+
     return 0;
 }

--- a/tests/poolstl_test.cpp
+++ b/tests/poolstl_test.cpp
@@ -26,15 +26,6 @@ namespace Catch {
     };
 }
 
-#if !POOLSTL_HAVE_CXX17
-namespace poolstl {
-    // To make tests work on C++14.
-    // Tests use par_if(false) to exercise the par_if code path.
-    execution::sequenced_policy par_if(bool) {
-        return seq;
-    }
-}
-#endif
 
 TEST_CASE("any_all_none", "[alg][algorithm]") {
     for (auto num_threads : test_thread_counts) {

--- a/tests/poolstl_test.cpp
+++ b/tests/poolstl_test.cpp
@@ -293,13 +293,25 @@ TEST_CASE("sort", "[alg][algorithm]") {
                     case 1: scramble(source); break;
                     default: break;
                 }
-                std::vector<int> dest1(source);
-                std::vector<int> dest2(source);
 
-                std::sort(dest1.begin(), dest1.end());
-                std::sort(poolstl::par.on(pool), dest2.begin(), dest2.end());
+                for (auto which_impl : {0, 1}) {
+                    std::vector<int> dest1(source);
+                    std::vector<int> dest2(source);
 
-                REQUIRE(dest1 == dest2);
+                    std::sort(dest1.begin(), dest1.end());
+                    switch (which_impl) {
+                        case 0:
+                            std::sort(poolstl::par_if(false), dest2.begin(), dest2.end());
+                            break;
+                        case 1:
+                            std::sort(poolstl::par.on(pool), dest2.begin(), dest2.end());
+                            break;
+                        default:
+                            break;
+                    }
+
+                    REQUIRE(dest1 == dest2);
+                }
             }
         }
     }
@@ -322,13 +334,25 @@ TEST_CASE("stable_sort", "[alg][algorithm]") {
                     case 1: scramble(source); break;
                     default: break;
                 }
-                std::vector<stable_sort_element> dest1(source);
-                std::vector<stable_sort_element> dest2(source);
 
-                std::stable_sort(dest1.begin(), dest1.end());
-                std::stable_sort(poolstl::par.on(pool), dest2.begin(), dest2.end());
+                for (auto which_impl : {0, 1}) {
+                    std::vector<stable_sort_element> dest1(source);
+                    std::vector<stable_sort_element> dest2(source);
 
-                REQUIRE(dest1 == dest2);
+                    std::sort(dest1.begin(), dest1.end());
+                    switch (which_impl) {
+                        case 0:
+                            std::stable_sort(poolstl::par_if(false), dest2.begin(), dest2.end());
+                            break;
+                        case 1:
+                            std::stable_sort(poolstl::par.on(pool), dest2.begin(), dest2.end());
+                            break;
+                        default:
+                            break;
+                    }
+
+                    REQUIRE(dest1 == dest2);
+                }
             }
         }
     }
@@ -604,6 +628,26 @@ TEST_CASE("iota_iter(def)", "[iterator]") {
     // default constructible
     iota_iter<long> c;
     REQUIRE(*c == 0);
+}
+
+struct gettable {
+    explicit gettable(int v): value(v) {}
+    int value;
+    POOLSTL_NO_DISCARD int get() const { return value; }
+};
+
+TEST_CASE("getting_iter", "[coverage]") {
+    // Tests for required functionality not exercised in the proper tests.
+    std::vector<gettable> vec = {gettable(0), gettable(1), gettable(2), gettable(3)};
+    auto iter = poolstl::internal::getting_iter<std::vector<gettable>::iterator>(vec.begin());
+    REQUIRE(*iter == 0);
+    REQUIRE(iter[0] == 0);
+    REQUIRE(iter[2] == 2);
+}
+
+TEST_CASE("seq", "[coverage]") {
+    // Tests for required functionality not exercised in the proper tests.
+    REQUIRE_THROWS(poolstl::seq.pool());
 }
 
 std::mt19937 rng{1};


### PR DESCRIPTION
Some optimizations to reduce final binary size. Can be significant if there are many different parallel calls, for example if a template function with many instances uses poolSTL.

 * Remove unnecessary intermediate lambdas in algorithms.
 * Upgrade task_thread_pool so it does not create an intermediate packaged_task when a future is returned (only works on non-MSVC, as [MSVC's packaged_task is not movable even though it should be](https://developercommunity.visualstudio.com/t/unable-to-move-stdpackaged-task-into-any-stl-conta/108672))
 * Add an experimental policy that uses threads directly, not using a thread pool. This can greatly reduce the binary size as it no longer generates any task packaging methods, with the downside that threads cannot be reused.