### PR TITLE
Add parallel `std::partition` and use it to improve sort

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Algorithms are added on an as-needed basis. If you need one [open an issue](http
 * [`fill`](https://en.cppreference.com/w/cpp/algorithm/fill), [`fill_n`](https://en.cppreference.com/w/cpp/algorithm/fill_n)
 * [`find`](https://en.cppreference.com/w/cpp/algorithm/find), [`find_if`](https://en.cppreference.com/w/cpp/algorithm/find_if), [`find_if_not`](https://en.cppreference.com/w/cpp/algorithm/find_if_not)
 * [`for_each`](https://en.cppreference.com/w/cpp/algorithm/for_each), [`for_each_n`](https://en.cppreference.com/w/cpp/algorithm/for_each_n)
+* [`partition`](https://en.cppreference.com/w/cpp/algorithm/partition)
 * [`sort`](https://en.cppreference.com/w/cpp/algorithm/sort), [`stable_sort`](https://en.cppreference.com/w/cpp/algorithm/stable_sort)
 * [`transform`](https://en.cppreference.com/w/cpp/algorithm/transform)
 
@@ -197,9 +198,9 @@ for_each()/real_time                                               94.6 ms      
 for_each(poolstl::par)/real_time                                   18.7 ms        0.044 ms           36
 for_each(std::execution::par)/real_time                            15.3 ms         12.9 ms           46
 sort()/real_time                                                    603 ms          602 ms            1
-sort(poolstl::par)/real_time                                        137 ms         11.8 ms            5
+sort(poolstl::par)/real_time                                        112 ms         6.64 ms            6
 sort(std::execution::par)/real_time                                 113 ms          102 ms            6
-pluggable_sort(poolstl::par, ..., pdqsort)/real_time               91.8 ms         11.9 ms            7
+pluggable_sort(poolstl::par, ..., pdqsort)/real_time               71.7 ms         6.67 ms           10
 transform()/real_time                                              95.0 ms         94.9 ms            7
 transform(poolstl::par)/real_time                                  17.4 ms        0.037 ms           38
 transform(std::execution::par)/real_time                           15.3 ms         13.2 ms           45

--- a/include/poolstl/algorithm
+++ b/include/poolstl/algorithm
@@ -12,6 +12,66 @@
 #include "internal/ttp_impl.hpp"
 #include "internal/thread_impl.hpp"
 
+namespace poolstl {
+    /**
+     * NOTE: Iterators are expected to be random access.
+     *
+     * Like `std::sort`, but allows specifying the sequential sort method, which must have the
+     * same signature as the comparator version of `std::sort`.
+     *
+     * Implemented as a high-level quicksort that delegates to `sort_func`, in parallel, once the range has been
+     * sufficiently partitioned.
+     */
+    template <class ExecPolicy, class RandIt, class Compare>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, void>
+    pluggable_sort(ExecPolicy &&policy, RandIt first, RandIt last, Compare comp,
+                   void (sort_func)(RandIt, RandIt, Compare) = std::sort) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            sort_func(first, last, comp);
+            return;
+        }
+
+        // Parallel partition.
+        // The partition_p2 method spawns and waits for its own child task. A deadlock is possible if all worker
+        // threads are waiting for tasks that in turn have to workers to execute them. This is only an issue because
+        // our thread pool does not have the concept of dependencies.
+        // So ensure
+        auto& task_pool = *policy.pool();
+        std::atomic<int> allowed_parallel_partitions{(int)task_pool.get_num_threads() / 2};
+
+        auto part_func = [&task_pool, &allowed_parallel_partitions](RandIt chunk_first, RandIt chunk_last,
+                                   poolstl::internal::pivot_predicate<Compare,
+                                   typename std::iterator_traits<RandIt>::value_type> pred) {
+            if (allowed_parallel_partitions.fetch_sub(1) > 0) {
+                return poolstl::internal::partition_p2(task_pool, chunk_first, chunk_last, pred);
+            } else {
+                return std::partition(chunk_first, chunk_last, pred);
+            }
+        };
+
+        poolstl::internal::parallel_quicksort(std::forward<ExecPolicy>(policy), first, last, comp, sort_func, part_func,
+                                              poolstl::internal::quicksort_pivot<RandIt>);
+    }
+
+    /**
+     * NOTE: Iterators are expected to be random access.
+     *
+     * Like `std::sort`, but allows specifying the sequential sort method, which must have the
+     * same signature as the comparator version of `std::sort`.
+     *
+     * Implemented as a parallel high-level quicksort that delegates to `sort_func` once the range has been
+     * sufficiently partitioned.
+     */
+    template <class ExecPolicy, class RandIt>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, void>
+    pluggable_sort(ExecPolicy &&policy, RandIt first, RandIt last,
+                   void (sort_func)(RandIt, RandIt,
+                                    std::less<typename std::iterator_traits<RandIt>::value_type>) = std::sort){
+        using T = typename std::iterator_traits<RandIt>::value_type;
+        pluggable_sort(std::forward<ExecPolicy>(policy), first, last, std::less<T>(), sort_func);
+    }
+}
+
 namespace std {
 
     /**
@@ -211,6 +271,22 @@ namespace std {
 
     /**
      * NOTE: Iterators are expected to be random access.
+     * See std::partition https://en.cppreference.com/w/cpp/algorithm/partition
+     *
+     * Current implementation uses at most 2 threads.
+     */
+    template <class ExecPolicy, class RandIt, class Predicate>
+    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, RandIt>
+    partition(ExecPolicy &&policy, RandIt first, RandIt last, Predicate pred) {
+        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
+            return std::partition(first, last, pred);
+        }
+
+        return poolstl::internal::partition_p2(*policy.pool(), first, last, pred);
+    }
+
+    /**
+     * NOTE: Iterators are expected to be random access.
      * See std::sort https://en.cppreference.com/w/cpp/algorithm/sort
      */
     template <class ExecPolicy, class RandIt, class Compare>
@@ -221,11 +297,7 @@ namespace std {
             return;
         }
 
-        poolstl::internal::parallel_quicksort(std::forward<ExecPolicy>(policy), first, last, comp,
-                                              std::sort<RandIt, Compare>,
-                                              std::partition<RandIt, poolstl::internal::pivot_predicate<Compare,
-                                                  typename std::iterator_traits<RandIt>::value_type>>,
-                                              poolstl::internal::quicksort_pivot<RandIt>);
+        poolstl::pluggable_sort(std::forward<ExecPolicy>(policy), first, last, comp, std::sort<RandIt, Compare>);
     }
 
     /**
@@ -375,48 +447,6 @@ namespace poolstl {
         poolstl::internal::parallel_chunk_for_1_wait(std::forward<ExecPolicy>(policy), first, last,
                                                      for_each_chunk <RandIt, ChunkConstructor, UnaryFunction>,
                                                      (void*)nullptr, 1, construct, f);
-    }
-
-    /**
-     * NOTE: Iterators are expected to be random access.
-     *
-     * Like `std::sort`, but allows specifying the sequential sort method, which must have the
-     * same signature as the comparator version of `std::sort`.
-     *
-     * Implemented as a high-level quicksort that delegates to `sort_func`, in parallel, once the range has been
-     * sufficiently partitioned.
-     */
-    template <class ExecPolicy, class RandIt, class Compare>
-    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, void>
-    pluggable_sort(ExecPolicy &&policy, RandIt first, RandIt last, Compare comp,
-                   void (sort_func)(RandIt, RandIt, Compare) = std::sort) {
-        if (poolstl::internal::is_seq<ExecPolicy>(policy)) {
-            sort_func(first, last, comp);
-            return;
-        }
-
-        poolstl::internal::parallel_quicksort(std::forward<ExecPolicy>(policy), first, last, comp, sort_func,
-                                              std::partition<RandIt, poolstl::internal::pivot_predicate<Compare,
-                                                  typename std::iterator_traits<RandIt>::value_type>>,
-                                              poolstl::internal::quicksort_pivot<RandIt>);
-    }
-
-    /**
-     * NOTE: Iterators are expected to be random access.
-     *
-     * Like `std::sort`, but allows specifying the sequential sort method, which must have the
-     * same signature as the comparator version of `std::sort`.
-     *
-     * Implemented as a parallel high-level quicksort that delegates to `sort_func` once the range has been
-     * sufficiently partitioned.
-     */
-    template <class ExecPolicy, class RandIt>
-    poolstl::internal::enable_if_poolstl_policy<ExecPolicy, void>
-    pluggable_sort(ExecPolicy &&policy, RandIt first, RandIt last,
-                   void (sort_func)(RandIt, RandIt,
-                                    std::less<typename std::iterator_traits<RandIt>::value_type>) = std::sort){
-        using T = typename std::iterator_traits<RandIt>::value_type;
-        pluggable_sort(std::forward<ExecPolicy>(policy), first, last, std::less<T>(), sort_func);
     }
 
     /**

--- a/include/poolstl/seq_fwd.hpp
+++ b/include/poolstl/seq_fwd.hpp
@@ -97,7 +97,9 @@ namespace std {
     POOLSTL_DEFINE_SEQ_FWD(std, for_each_n)
 #endif
 
+    POOLSTL_DEFINE_SEQ_FWD(std, partition)
     POOLSTL_DEFINE_SEQ_FWD(std, transform)
+    POOLSTL_DEFINE_SEQ_FWD(std, sort)
 
     // <numeric>
 

--- a/include/poolstl/variant_policy.hpp
+++ b/include/poolstl/variant_policy.hpp
@@ -105,7 +105,9 @@ namespace std {
     POOLSTL_DEFINE_PAR_IF_FWD(std, for_each_n)
 #endif
 
+    POOLSTL_DEFINE_PAR_IF_FWD(std, partition)
     POOLSTL_DEFINE_PAR_IF_FWD(std, transform)
+    POOLSTL_DEFINE_PAR_IF_FWD(std, sort)
 
     // <numeric>
 
@@ -121,6 +123,7 @@ namespace poolstl {
     // <poolstl/algorithm>
 
     POOLSTL_DEFINE_PAR_IF_FWD_VOID(poolstl, for_each_chunk)
+    POOLSTL_DEFINE_PAR_IF_FWD_VOID(poolstl, pluggable_sort)
 }
 #endif
 


### PR DESCRIPTION
This version of partition only uses two threads (spawns and waits for one additional task).

Used to speed up `pluggable_sort`. Also made `std::sort` call `pluggable_sort` explicitly so it benefits too.