### PR TITLE
Add missing find_dependency to config.cmake.in

### DIFF
--- a/cmake/config.cmake.in
+++ b/cmake/config.cmake.in
@@ -1,6 +1,9 @@
 
 @PACKAGE_INIT@
 
+include(CMakeFindDependencyMacro)
+find_dependency(Threads)
+
 include("${CMAKE_CURRENT_LIST_DIR}/@PROJECT_NAME@Targets.cmake")
 
 set_and_check(@PROJECT_NAME@_INCLUDE_DIR "@PACKAGE_CMAKE_INSTALL_INCLUDEDIR@")


### PR DESCRIPTION
This adds a call to `find_dependency` for the Threads module which is a transitive dependency for any consumer application that uses poolSTL. Adding `find_dependency` to the CMake config avoids a CMake error if users do not resolve the dependency themselves, see also the discussion at https://github.com/microsoft/vcpkg/pull/38951#issuecomment-2132699463.